### PR TITLE
chore: release v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1](https://github.com/philipcristiano/rust-sql-test/releases/tag/v0.0.1) - 2023-12-24
+
+### Other
+- Test atlas Github workflow ([#4](https://github.com/philipcristiano/rust-sql-test/pull/4))
+- Merge pull request [#2](https://github.com/philipcristiano/rust-sql-test/pull/2) from philipcristiano/dependabot/github_actions/agenthunt/conventional-commit-checker-action-2.0.0
+- *(deps)* bump the patch-dependencies group with 2 updates
+- Start with Atlas and SQLX
+- Initial commit


### PR DESCRIPTION
## 🤖 New release
* `rust-sql-test`: 0.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.1](https://github.com/philipcristiano/rust-sql-test/releases/tag/v0.0.1) - 2023-12-24

### Other
- Test atlas Github workflow ([#4](https://github.com/philipcristiano/rust-sql-test/pull/4))
- Merge pull request [#2](https://github.com/philipcristiano/rust-sql-test/pull/2) from philipcristiano/dependabot/github_actions/agenthunt/conventional-commit-checker-action-2.0.0
- *(deps)* bump the patch-dependencies group with 2 updates
- Start with Atlas and SQLX
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).